### PR TITLE
Add Slack and GitHub integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+SLACK_BOT_TOKEN=<your-slack-bot-token>
+GITHUB_TOKEN=<your-github-token>

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,11 @@ cache:
   directories:
     - $HOME/.npm
 script: npm test
+
+env:
+  global:
+    - SLACK_BOT_TOKEN=<your-slack-bot-token>
+    - GITHUB_TOKEN=<your-github-token>
+
+script:
+  - npm start

--- a/README.md
+++ b/README.md
@@ -5,3 +5,28 @@
 ## [Changelog](CHANGELOG.md)
 
 ## [License](LICENSE)
+
+## Setting up Slack and GitHub Integration
+
+1. Create a Slack App at https://api.slack.com/apps and install it to your workspace.
+2. Create a GitHub App at https://github.com/settings/apps and install it to your repository.
+3. Create a `.env` file in the root of your project and add the following environment variables:
+
+```
+SLACK_BOT_TOKEN=<your-slack-bot-token>
+GITHUB_TOKEN=<your-github-token>
+```
+
+## Running the Bot
+
+1. Install dependencies:
+
+```
+npm install
+```
+
+2. Start the bot:
+
+```
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
 		"wapuu",
 		"wordpress"
 	],
-	"dependencies": {},
+	"dependencies": {
+		"@slack/web-api": "^6.1.0",
+		"@octokit/rest": "^18.0.12",
+		"dotenv": "^8.2.0"
+	},
 	"devDependencies": {
 		"@commitlint/cli": "^6.1.3",
 		"@commitlint/config-conventional": "^6.1.3",
@@ -40,6 +44,7 @@
 	"scripts": {
 		"commitmsg": "commitlint -e $GIT_PARAMS",
 		"lint": "eslint .",
-		"test": "npm run lint"
+		"test": "npm run lint",
+		"start": "node src/bot.js"
 	}
 }

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,0 +1,39 @@
+require('dotenv').config();
+const { WebClient } = require('@slack/web-api');
+const { Octokit } = require('@octokit/rest');
+
+const slackClient = new WebClient(process.env.SLACK_BOT_TOKEN);
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+slackClient.on('message', async (event) => {
+  if (event.text.includes('github')) {
+    const repo = event.text.split(' ')[1];
+    const response = await octokit.repos.get({
+      owner: 'your-github-username',
+      repo: repo,
+    });
+    slackClient.chat.postMessage({
+      channel: event.channel,
+      text: `Repository ${repo} has ${response.data.stargazers_count} stars.`,
+    });
+  }
+});
+
+slackClient.on('reaction_added', async (event) => {
+  const response = await slackClient.reactions.get({
+    channel: event.item.channel,
+    timestamp: event.item.ts,
+  });
+  slackClient.chat.postMessage({
+    channel: event.item.channel,
+    text: `You reacted with :${event.reaction}: to a message.`,
+  });
+});
+
+octokit.hook.before('request', async (options) => {
+  console.log(`Requesting ${options.method} ${options.url}`);
+});
+
+octokit.hook.after('request', async (response, options) => {
+  console.log(`Received ${response.status} from ${options.method} ${options.url}`);
+});


### PR DESCRIPTION
Add Slack and GitHub integration to the project.

* **Dependencies**: Add `@slack/web-api`, `@octokit/rest`, and `dotenv` to `dependencies` in `package.json`. Add a `start` script to run the bot.
* **Documentation**: Update `README.md` with instructions for setting up Slack and GitHub integration and running the bot.
* **Environment Variables**: Add a `.env` file with environment variables for Slack and GitHub tokens.
* **Bot Initialization**: Add `src/bot.js` to initialize Slack and GitHub clients, handle Slack events, and handle GitHub events.
* **CI Configuration**: Update `.travis.yml` to include environment variables for Slack and GitHub tokens and add a test script to run the bot.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wapuubot/wapuubot?shareId=5e741a9d-0226-46a6-9817-6f4f952e61e0).